### PR TITLE
Avoid detection preventing login

### DIFF
--- a/src/tiktok_uploader/auth.py
+++ b/src/tiktok_uploader/auth.py
@@ -40,7 +40,7 @@ def interactive_login(
 
     with sync_playwright() as p:
         # Launch visible browser
-        browser = p.chromium.launch(headless=False)
+        browser = p.chromium.launch(headless=False, args=["--disable-blink-features=AutomationControlled"])
         context = browser.new_context(viewport={"width": 1280, "height": 800})
         page = context.new_page()
 


### PR DESCRIPTION
Using this arg, we can keep TikTok from detecting we are in an automated environment, thus allowing us to sign in.